### PR TITLE
Add model execution scripts for Qwen and Llama models

### DIFF
--- a/run_models.sh
+++ b/run_models.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Script to run mt-prompt.py with specified models
+# Created: $(date)
+
+# Set up error handling
+set -e
+
+echo "Starting debate-LM model execution script..."
+
+# Change to the repository directory
+cd /workspace/debate-LM
+
+# Install requirements
+echo "Installing requirements..."
+pip install -r requirements.txt
+
+# Create output directory if it doesn't exist
+mkdir -p output
+
+# Run the first model: Qwen/Qwen2.5-72B-Instruct
+echo "Running mt-prompt.py with Qwen/Qwen2.5-72B-Instruct..."
+python mt-prompt.py "Qwen/Qwen2.5-72B-Instruct"
+
+# Run the second model: meta-llama/Llama-3.3-70B-Instruct
+echo "Running mt-prompt.py with meta-llama/Llama-3.3-70B-Instruct..."
+python mt-prompt.py "meta-llama/Llama-3.3-70B-Instruct"
+
+echo "All models have been processed successfully!"
+echo "Results are available in the output directory."

--- a/run_models_advanced.sh
+++ b/run_models_advanced.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+
+# Advanced script to run mt-prompt.py with specified models
+# Created: $(date)
+
+# Set up error handling
+set -e
+
+# Default values
+BATCH_SIZE=4
+NUM_RESPONSES=5
+OUTPUT_DIR="output"
+INSTALL_DEPS=true
+
+# Function to display usage information
+usage() {
+    echo "Usage: $0 [OPTIONS]"
+    echo "Run mt-prompt.py with specified models"
+    echo ""
+    echo "Options:"
+    echo "  -b, --batch-size SIZE     Set batch size (default: 4)"
+    echo "  -r, --responses NUM       Number of responses per question (default: 5)"
+    echo "  -o, --output-dir DIR      Custom output directory (default: output)"
+    echo "  -s, --skip-install        Skip installing dependencies"
+    echo "  -h, --help                Display this help message"
+    exit 1
+}
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -b|--batch-size)
+            BATCH_SIZE="$2"
+            shift 2
+            ;;
+        -r|--responses)
+            NUM_RESPONSES="$2"
+            shift 2
+            ;;
+        -o|--output-dir)
+            OUTPUT_DIR="$2"
+            shift 2
+            ;;
+        -s|--skip-install)
+            INSTALL_DEPS=false
+            shift
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            echo "Unknown option: $1"
+            usage
+            ;;
+    esac
+done
+
+echo "Starting debate-LM model execution script..."
+
+# Change to the repository directory
+cd /workspace/debate-LM
+
+# Install requirements if not skipped
+if [ "$INSTALL_DEPS" = true ]; then
+    echo "Installing requirements..."
+    pip install -r requirements.txt
+else
+    echo "Skipping dependency installation..."
+fi
+
+# Create output directory if it doesn't exist
+mkdir -p "$OUTPUT_DIR"
+
+# Define models to run
+MODELS=(
+    "Qwen/Qwen2.5-72B-Instruct"
+    "meta-llama/Llama-3.3-70B-Instruct"
+)
+
+# Run each model
+for MODEL in "${MODELS[@]}"; do
+    echo "Running mt-prompt.py with $MODEL..."
+    
+    # Construct command with options
+    CMD="python mt-prompt.py \"$MODEL\" --batch_size $BATCH_SIZE --num_responses $NUM_RESPONSES"
+    
+    # Add output directory if custom
+    if [ "$OUTPUT_DIR" != "output" ]; then
+        CMD="$CMD --output_dir $OUTPUT_DIR"
+    fi
+    
+    echo "Executing: $CMD"
+    eval $CMD
+    
+    echo "Completed processing $MODEL"
+    echo "----------------------------------------"
+done
+
+echo "All models have been processed successfully!"
+echo "Results are available in the $OUTPUT_DIR directory."

--- a/run_scripts_README.md
+++ b/run_scripts_README.md
@@ -1,0 +1,61 @@
+# Model Execution Scripts
+
+This directory contains scripts to run the `mt-prompt.py` with specified models.
+
+## Basic Script: `run_models.sh`
+
+This script runs `mt-prompt.py` with the following models:
+- Qwen/Qwen2.5-72B-Instruct
+- meta-llama/Llama-3.3-70B-Instruct
+
+### Usage
+
+```bash
+./run_models.sh
+```
+
+The script will:
+1. Install all dependencies from `requirements.txt`
+2. Run each model sequentially with default parameters
+3. Save results to the `output` directory
+
+## Advanced Script: `run_models_advanced.sh`
+
+This script provides more flexibility with command-line options.
+
+### Usage
+
+```bash
+./run_models_advanced.sh [OPTIONS]
+```
+
+### Options
+
+- `-b, --batch-size SIZE`: Set batch size (default: 4)
+- `-r, --responses NUM`: Number of responses per question (default: 5)
+- `-o, --output-dir DIR`: Custom output directory (default: output)
+- `-s, --skip-install`: Skip installing dependencies
+- `-h, --help`: Display help message
+
+### Examples
+
+Run with default settings:
+```bash
+./run_models_advanced.sh
+```
+
+Run with custom batch size and number of responses:
+```bash
+./run_models_advanced.sh --batch-size 2 --responses 3
+```
+
+Run with custom output directory and skip dependency installation:
+```bash
+./run_models_advanced.sh --output-dir custom_results --skip-install
+```
+
+## Notes
+
+- Both scripts will create the output directory if it doesn't exist
+- The scripts run the models sequentially, which may take a significant amount of time
+- Results are saved in CSV format in the output directory


### PR DESCRIPTION
## Description
This PR adds bash scripts to run mt-prompt.py with Qwen/Qwen2.5-72B-Instruct and meta-llama/Llama-3.3-70B-Instruct models.

## Changes
- Added `run_models.sh`: Basic script to run both models with default parameters
- Added `run_models_advanced.sh`: Advanced script with command-line options for customization
- Added `run_scripts_README.md`: Documentation for using the scripts

## How to use
1. Make the scripts executable: `chmod +x run_models.sh run_models_advanced.sh`
2. Run the basic script: `./run_models.sh`
3. Or run the advanced script with options: `./run_models_advanced.sh --batch-size 2 --responses 3`

Both scripts will install the required dependencies from requirements.txt and run the models sequentially.